### PR TITLE
fixed npm run missing from "start" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
 
   "scripts": {
-    "start": "npm install && npm run templates && serve",
+    "start": "npm install && npm run templates && npm run serve",
     "serve": "node index.js",
 
     "watch": "npm run watch/templates & npm run serve & npm run watch/browser",


### PR DESCRIPTION
Added npm run to line 8 for "npm run serve"
